### PR TITLE
TMS-1017: Add image alt-text to imported news

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1017: Add image alt-text to imported news
+
 ## [1.8.9] - 2024-02-01
 
 - TMS-980: Add redipress_include_search to include component contents in search results

--- a/lib/Traits/EnrichPost.php
+++ b/lib/Traits/EnrichPost.php
@@ -33,10 +33,12 @@ trait EnrichPost {
         int $excerpt_length = 160
     ) {
         if ( $use_images ) {
-            $api_image = get_field( 'image_url', $post->ID );
+            $api_image     = get_field( 'image_url', $post->ID );
+            $api_image_alt = get_field( 'image_alt', $post->ID );
 
             if ( ! empty( $api_image ) ) {
                 $post->api_image_url = $api_image;
+                $post->api_image_alt = $api_image_alt;
             }
             else {
                 $post->featured_image = has_post_thumbnail( $post->ID )

--- a/models/single.php
+++ b/models/single.php
@@ -86,6 +86,7 @@ class Single extends BaseModel {
             : $single->image;
 
         $single->api_image_url = empty( $single->image ) ? get_field( 'image_url' ) : false;
+        $single->api_image_alt = empty( $single->image ) ? get_field( 'image_alt' ) : false;
         $single->has_image     = ! empty( $single->image ) || ! empty( $single->api_image_url );
 
         if ( 'blog-article' === $single->post_type ) {
@@ -136,6 +137,7 @@ class Single extends BaseModel {
                     : [];
 
                 $item->api_image_url = get_field( 'image_url', $item->ID );
+                $item->api_image_alt = get_field( 'image_alt', $item->ID );
                 $has_image           = $item->image_id !== 0 || ! empty( $item->api_image_url );
 
                 if ( ! $has_image ) {

--- a/partials/single.dust
+++ b/partials/single.dust
@@ -37,7 +37,9 @@
 
                                     {?content.api_image_url}
                                         <div class="entry__figure pt-2">
-                                            <img src="{content.api_image_url|url}" loading="lazy"/>
+                                            <img src="{content.api_image_url|url}"
+                                             {?content.api_image_alt}alt="{content.api_image_alt|attr}"{/content.api_image_alt}
+                                             loading="lazy" />
                                         </div>
 
                                         {>"views/single/single-meta" spacing_class="pt-5 pt-4-desktop pb-5 p-5-tablet" /}


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1017 Drupalista tulevan uutisen pääkuvapaikan kuvan alt-teksti puuttuu
Task: https://hiondigital.atlassian.net/browse/TMS-1017

## Description
Add api-images alternative text to the news main-image if found

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
