### PR TITLE
TMS-1150: Move header chat script from head to header

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1150: Move header chat script from head to header
+
 ## [1.9.5] - 2025-04-30
 
 - TMS-1139: Add another link-button to CTA-component

--- a/partials/shared/header.dust
+++ b/partials/shared/header.dust
@@ -10,10 +10,6 @@
             {?Header.head_custom_scripts}
                 {Header.head_custom_scripts|s}
             {/Header.head_custom_scripts}
-
-            {?Header.chat}
-                {Header.chat|s}
-            {/Header.chat}
         </head>
 
         <body class="{#WP.body_class}{.}{@sep} {/sep}{/WP.body_class}">
@@ -26,6 +22,10 @@
             <a href="#main-content" class="skip-to-content">
                 {Strings.s.header.skip_to_content|s}
             </a>
+
+            {?Header.chat}
+                {Header.chat|s}
+            {/Header.chat}
 
             {?Header.exception_notice}
                 {>"shared/header-notice" /}


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1150 Saavutettavuus: Tredu.fi:ssä ekana näppäimistöllä liikkuessa chat, ei pitäisi
Task: https://hiondigital.atlassian.net/browse/TMS-1150

## Description
Move header chat script from head to header, this makes the "skip to content" link to be first focused element when surfing the website with keyboard

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

