### PR TITLE
TMS-1259: Disable link underline in theme.json

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- TMS-1259: Disable link underline in theme.json
+
 ## [1.16.1] - 2025-12-25
 
 - TMS-1254: Fix for showing apply methods in page-program

--- a/theme.json
+++ b/theme.json
@@ -11,5 +11,14 @@
         "typography": {
             "dropCap": false
         }
+    },
+    "styles": {
+        "elements": {
+            "link": {
+                "typography": {
+                    "textDecoration": false
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Project: Tampereen kaupunki, konsernihallinto / Tietohallintoyksikkö:
Project task: Tampere multisite support

Task: https://hiondigital.atlassian.net/browse/TMS-1259
Task title: WP Update 6.9.2

## Description
Disable link underline in theme.json, as it breaks the themes styling by default

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
